### PR TITLE
Separate state tables

### DIFF
--- a/db/data/README.md
+++ b/db/data/README.md
@@ -12,7 +12,6 @@ Insert or update database entries for the obs_id -> tile mapping in the POSSUM s
 
 * `tile`
 * `associated_tile`
-* `field_tile`
 
 It ingests a large number of files, each containing the following sort of information (see below) and uses the information in the filename to indicate which observation. For example, the filename [`EMU-FULL_2317+04B_1.50d.csv`](EMU_full_survey/mapping_1.5deg/EMU-FULL_2317+04B_1.50d.csv) might contain:
 
@@ -50,7 +49,7 @@ PIXELS,CRPIX_RA,CRPIX_DEC,CRVAL_RA [deg],CRVAL_DEC [deg]
 A new script (`update_tilemap.py`) for a second request from the POSSUM team. This script will:
 
 * Assume that the observations and pixel (`possum.observation` and `possum.tile` tables respectively) are already populated
-* You have two new files for the EMU (band 1) and WALLABY (band 2) tile maps (`possum.associated_tile` and `possum.field_tile` maps)
+* You have two new files for the EMU (band 1) and WALLABY (band 2) tile maps (`possum.associated_tile` maps)
 * The table mapping entries exist and need to be overwritten
 
 An example snippet from this file is provided by Cameron Van Eck (cameron.vaneck@anu.edu.au):
@@ -71,6 +70,6 @@ PIXEL,SB1,SB2,SB3,SB4,SB5,SB6,SB7,SB8,SB9,SB10
 
 This code will (in a transaction):
 
-* Clear the `associated_tile` and `field_tile` tables
+* Clear the `associated_tile` tables
 * Insert the new entries
 * Identify tiles without associated sbids and log them

--- a/db/data/update_tilemap.py
+++ b/db/data/update_tilemap.py
@@ -46,7 +46,6 @@ async def insert_tilemap(conn, filename, prefix):
             for o in obs_ids:
                 tile_maps.append((o, tile_id))
     await conn.executemany('INSERT INTO possum.associated_tile (name, tile) VALUES ($1, $2)', tile_maps)
-    await conn.executemany('INSERT INTO possum.field_tile (name, tile) VALUES ($1, $2)', tile_maps)
     print(f'Insert file {filename} complete')
     return
 
@@ -78,12 +77,10 @@ async def main(argv):
     db_pool = await asyncpg.create_pool(dsn=None, **dsn)
     async with db_pool.acquire() as conn:
         async with conn.transaction():
-            print('Clearing tables (associated_tile, field_tile)')
+            print('Clearing tables (associated_tile)')
             await conn.execute('TRUNCATE possum.associated_tile;')
-            await conn.execute('TRUNCATE possum.field_tile;')
             print('Resetting sequences')
             await conn.execute('ALTER sequence possum.associated_tile_id_seq RESTART WITH 1;')
-            await conn.execute('ALTER sequence possum.field_tile_id_seq RESTART WITH 1;')
             print('Tables cleared, sequences reset')
 
             # ingest all tiles (skip if exists)

--- a/possum/pipeline_validation/admin.py
+++ b/possum/pipeline_validation/admin.py
@@ -1,8 +1,20 @@
 from django.contrib import admin
-from .models import (ObservationBand1_1DPipelineValidation, ObservationBand2_1DPipelineValidation,
+from django.utils.html import format_html
+from .models import (ObservationStatesBand1, ObservationStatesBand2,
                      PartialTilePipelineRegionsBand1, PartialTilePipelineRegionsBand2,
-                     SurveyTiles_3DPipelineBand1,  SurveyTiles_3DPipelineBand2)
+                     TileStatesBand1, TileStatesBand2)
 
+def pipeline_state_colour(state):
+    colour = 'DodgerBlue'
+    if state == 'PENDING':
+        colour = 'orange'
+    elif state == 'RUNNING':
+        colour = 'SlateBlue'
+    elif state == 'COMPLETED':
+        colour = 'limegreen'
+    elif state == 'FAILED':
+        colour = 'Tomato'
+    return colour
 class PartialTile1DBand1Admin(admin.ModelAdmin):
     list_display = [field.name for field in PartialTilePipelineRegionsBand1._meta.get_fields()]
     search_fields = ('id', 'observation__name', 'sbid', 'tile1__tile', 'tile2__tile', 'tile3__tile',
@@ -28,10 +40,12 @@ class PartialTile1DBand2Admin(admin.ModelAdmin):
         qs = super(PartialTile1DBand2Admin, self).get_queryset(request)
         return qs.filter()
 
-class Observation1DBand1Admin(admin.ModelAdmin):
-    readonly_fields = ('name', 'sbid', '_1d_pipeline_validation', 'single_SB_1D_pipeline')
-    list_display = [field.name for field in ObservationBand1_1DPipelineValidation._meta.get_fields()]
-    search_fields = ['name__name', 'sbid', '_1d_pipeline_validation', 'single_SB_1D_pipeline', 'comments']
+class ObservationStatesBand1Admin(admin.ModelAdmin):
+    # only comments can be edited
+    readonly_fields = ('name', 'sbid', '_1d_pipeline_validation', 'single_SB_1D_pipeline', 'mfs_state', 'mfs_update', 'cube_state', 'cube_update')
+    list_display = ('name', 'sbid', '_1d_pipeline_validation', 'single_SB_1D_pipeline', 'comments',
+                    'colour_mfs_state', 'mfs_update', 'colour_cube_state', 'cube_update',)
+    search_fields = [field.name for field in ObservationStatesBand1._meta.get_fields()]
 
     def has_add_permission(self, request, obj=None):
         return False
@@ -43,13 +57,39 @@ class Observation1DBand1Admin(admin.ModelAdmin):
         return False
 
     def get_queryset(self, request):
-        qs = super(Observation1DBand1Admin, self).get_queryset(request)
+        qs = super(ObservationStatesBand1Admin, self).get_queryset(request)
         return qs.filter()
+    
+    def colour_mfs_state(self, obj):
+        state = obj.mfs_state
+        if state is None:
+            return '-'
+        colour = pipeline_state_colour(state)
+        return format_html('<span style="color: {};">{}</span>',
+                           colour,
+                           obj.mfs_state)
 
-class Observation1DBand2Admin(admin.ModelAdmin):
-    readonly_fields = ('name', 'sbid', '_1d_pipeline_validation', 'single_SB_1D_pipeline')
-    list_display = [field.name for field in ObservationBand2_1DPipelineValidation._meta.get_fields()]
-    search_fields = [field.name for field in ObservationBand2_1DPipelineValidation._meta.get_fields()]
+    colour_mfs_state.admin_order_field = 'mfs_state'
+    colour_mfs_state.short_description = 'mfs state'
+
+    def colour_cube_state(self, obj):
+        state = obj.cube_state
+        if state is None:
+            return '-'
+        colour = pipeline_state_colour(state)
+        return format_html('<span style="color: {};">{}</span>',
+                           colour,
+                           obj.cube_state)
+
+    colour_cube_state.admin_order_field = 'cube_state'
+    colour_cube_state.short_description = 'cube state'
+
+class ObservationStatesBand2Admin(admin.ModelAdmin):
+    # only comments can be edited
+    readonly_fields = ('name', 'sbid', '_1d_pipeline_validation', 'single_SB_1D_pipeline', 'mfs_state', 'mfs_update', 'cube_state', 'cube_update')
+    list_display = ('name', 'sbid', '_1d_pipeline_validation', 'single_SB_1D_pipeline', 'comments',
+                    'colour_mfs_state', 'mfs_update', 'colour_cube_state', 'cube_update',)
+    search_fields = [field.name for field in ObservationStatesBand2._meta.get_fields()]
 
     def has_add_permission(self, request, obj=None):
         return False
@@ -61,14 +101,107 @@ class Observation1DBand2Admin(admin.ModelAdmin):
         return False
 
     def get_queryset(self, request):
-        qs = super(Observation1DBand2Admin, self).get_queryset(request)
+        qs = super(ObservationStatesBand2Admin, self).get_queryset(request)
+        return qs.filter()
+    
+    def colour_mfs_state(self, obj):
+        state = obj.mfs_state
+        if state is None:
+            return '-'
+        colour = pipeline_state_colour(state)
+        return format_html('<span style="color: {};">{}</span>',
+                           colour,
+                           obj.mfs_state)
+
+    colour_mfs_state.admin_order_field = 'mfs_state'
+    colour_mfs_state.short_description = 'mfs state'
+
+    def colour_cube_state(self, obj):
+        state = obj.cube_state
+        if state is None:
+            return '-'
+        colour = pipeline_state_colour(state)
+        return format_html('<span style="color: {};">{}</span>',
+                           colour,
+                           obj.cube_state)
+
+    colour_cube_state.admin_order_field = 'cube_state'
+    colour_cube_state.short_description = 'cube state'
+
+class TileStatesBand1Admin(admin.ModelAdmin):
+    # Make sure 3d_val_comments can be updated
+    readonly_fields = ('tile_id', '_3d_pipeline', '_3d_pipeline_ingest', '_3d_val_link', 
+                       'mfs_complete', 'cube_complete', 'colour_mfs_state', 'colour_cube_state')
+    list_display = [field.name for field in TileStatesBand1._meta.get_fields()]
+    search_fields = [field.name for field in TileStatesBand1._meta.get_fields()]
+          
+    def colour_cube_state(self, obj):
+        state = obj.cube_state
+        if state is None:
+            return '-'
+        colour = pipeline_state_colour(state)
+        return format_html('<span style="color: {};">{}</span>',
+                           colour,
+                           obj.cube_state)
+
+    colour_cube_state.admin_order_field = 'cube_state'
+    colour_cube_state.short_description = 'cube tile state'
+
+    def colour_mfs_state(self, obj):
+        state = obj.mfs_state
+        if state is None:
+            return '-'
+        colour = pipeline_state_colour(state)
+        return format_html('<span style="color: {};">{}</span>',
+                           colour,
+                           obj.mfs_state)
+
+    colour_mfs_state.admin_order_field = 'mfs_state'
+    colour_mfs_state.short_description = 'mfs tile state'
+    
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return True
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def get_queryset(self, request):
+        qs = super(TileStatesBand1Admin, self).get_queryset(request)
         return qs.filter()
 
-class SurveyTiles3DPipelineBand1Admin(admin.ModelAdmin):
-    readonly_fields = ('tile_id', '_3d_pipeline', '_3d_pipeline_ingest', '_3d_val_link')
-    list_display = [field.name for field in SurveyTiles_3DPipelineBand1._meta.get_fields()]
-    search_fields = ('tile_id__tile', '_3d_pipeline', '_3d_pipeline_ingest', '_3d_val_comments',
-                     '_3d_pipeline_val', '_3d_pipeline_validator', '_3d_val_link')
+class TileStatesBand2Admin(admin.ModelAdmin):
+    # Make sure 3d_val_comments can be updated
+    readonly_fields = ('tile_id', '_3d_pipeline', '_3d_pipeline_ingest', '_3d_val_link',
+                       'mfs_complete', 'cube_complete', 'colour_mfs_state', 'colour_cube_state')
+    list_display = [field.name for field in TileStatesBand2._meta.get_fields()]
+    search_fields = [field.name for field in TileStatesBand2._meta.get_fields()]
+    
+    def colour_cube_state(self, obj):
+        state = obj.cube_state
+        if state is None:
+            return '-'
+        colour = pipeline_state_colour(state)
+        return format_html('<span style="color: {};">{}</span>',
+                           colour,
+                           obj.cube_state)
+
+    colour_cube_state.admin_order_field = 'cube_state'
+    colour_cube_state.short_description = 'cube tile state'
+
+    def colour_mfs_state(self, obj):
+        state = obj.mfs_state
+        if state is None:
+            return '-'
+        colour = pipeline_state_colour(state)
+        return format_html('<span style="color: {};">{}</span>',
+                           colour,
+                           obj.mfs_state)
+
+    colour_mfs_state.admin_order_field = 'mfs_state'
+    colour_mfs_state.short_description = 'mfs tile state'
 
     def has_add_permission(self, request, obj=None):
         return False
@@ -80,31 +213,12 @@ class SurveyTiles3DPipelineBand1Admin(admin.ModelAdmin):
         return False
 
     def get_queryset(self, request):
-        qs = super(SurveyTiles3DPipelineBand1Admin, self).get_queryset(request)
-        return qs.filter()
-
-class SurveyTiles3DPipelineBand2Admin(admin.ModelAdmin):
-    readonly_fields = ('tile_id', '_3d_pipeline', '_3d_pipeline_ingest', '_3d_val_link')
-    list_display = [field.name for field in SurveyTiles_3DPipelineBand2._meta.get_fields()]
-    search_fields = ('tile_id__tile', '_3d_pipeline', '_3d_pipeline_ingest', '_3d_val_comments',
-                     '_3d_pipeline_val', '_3d_pipeline_validator', '_3d_val_link')
-
-    def has_add_permission(self, request, obj=None):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return True
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
-    def get_queryset(self, request):
-        qs = super(SurveyTiles3DPipelineBand2Admin, self).get_queryset(request)
-        return qs.filter()
+        qs = super(TileStatesBand2Admin, self).get_queryset(request)
+        qs = qs.order_by('mfs_complete', 'cube_complete')
 
 admin.site.register(PartialTilePipelineRegionsBand1, PartialTile1DBand1Admin)
 admin.site.register(PartialTilePipelineRegionsBand2, PartialTile1DBand2Admin)
-admin.site.register(ObservationBand1_1DPipelineValidation, Observation1DBand1Admin)
-admin.site.register(ObservationBand2_1DPipelineValidation, Observation1DBand2Admin)
-admin.site.register(SurveyTiles_3DPipelineBand1, SurveyTiles3DPipelineBand1Admin)
-admin.site.register(SurveyTiles_3DPipelineBand2, SurveyTiles3DPipelineBand2Admin)
+admin.site.register(ObservationStatesBand1Admin, ObservationStatesBand1Admin)
+admin.site.register(ObservationStatesBand2Admin, ObservationStatesBand2Admin)
+admin.site.register(TileStatesBand1Admin, TileStatesBand1Admin)
+admin.site.register(TileStatesBand2Admin, TileStatesBand2Admin)

--- a/possum/pipeline_validation/apps.py
+++ b/possum/pipeline_validation/apps.py
@@ -4,4 +4,4 @@ from django.apps import AppConfig
 class PipelineValidationConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'pipeline_validation'
-    verbose_name = 'Pipeline Validation'
+    verbose_name = 'Processing States'

--- a/possum/pipeline_validation/models.py
+++ b/possum/pipeline_validation/models.py
@@ -55,31 +55,39 @@ class PartialTilePipelineRegionsBand2(models.Model):
         db_table = 'partial_tile_1d_pipeline_band2'
         unique_together = (('observation', 'sbid', 'tile1', 'tile2', 'tile3', 'tile4', 'type'),)
 
-class ObservationBand1_1DPipelineValidation(models.Model):
+class ObservationStatesBand1(models.Model):
     name = models.OneToOneField('survey.Observation', models.DO_NOTHING, db_column='name', to_field='name', primary_key=True)
     sbid = models.BigIntegerField(blank=True, null=True, db_column='sbid')
     _1d_pipeline_validation = models.CharField(blank=True, null=True, db_column='1d_pipeline_validation')
     single_SB_1D_pipeline = models.CharField(blank=True, null=True, db_column='single_sb_1d_pipeline')
     comments = models.TextField(blank=True, null=True, db_column='comments')
+    mfs_update = models.DateTimeField(blank=True, null=True)
+    mfs_state = models.TextField(blank=True, null=True)
+    cube_update = models.DateTimeField(blank=True, null=True)
+    cube_state = models.TextField(blank=True, null=True)
 
     class Meta:
-        verbose_name = "Observation 1D Pipeline - Band 1"
+        verbose_name = "Observation States - Band 1"
         managed = False
-        db_table = 'observation_1d_pipeline_band1'
+        db_table = 'observation_state_band1'
 
-class ObservationBand2_1DPipelineValidation(models.Model):
+class ObservationStatesBand2(models.Model):
     name = models.OneToOneField('survey.Observation', models.DO_NOTHING, db_column='name', to_field='name', primary_key=True)
     sbid = models.BigIntegerField(blank=True, null=True, db_column='sbid')
     _1d_pipeline_validation = models.CharField(blank=True, null=True, db_column='1d_pipeline_validation')
     single_SB_1D_pipeline = models.CharField(blank=True, null=True, db_column='single_sb_1d_pipeline')
     comments = models.TextField(blank=True, null=True, db_column='comments')
+    mfs_update = models.DateTimeField(blank=True, null=True)
+    mfs_state = models.TextField(blank=True, null=True)
+    cube_update = models.DateTimeField(blank=True, null=True)
+    cube_state = models.TextField(blank=True, null=True)
 
     class Meta:
-        verbose_name = "Observation 1D Pipeline - Band 2"
+        verbose_name = "Observation States - Band 2"
         managed = False
-        db_table = 'observation_1d_pipeline_band2'
+        db_table = 'observation_state_band2'
 
-class SurveyTiles_3DPipelineBand1(models.Model):
+class TileStatesBand1(models.Model):
     tile_id = models.OneToOneField('survey.Tile', models.DO_NOTHING, db_column='tile_id', to_field='tile', primary_key=True)
     _3d_pipeline = models.CharField(blank=True, null=True, db_column='3d_pipeline')
     _3d_pipeline_val = models.CharField( blank=True, null=True, choices=VALIDATED_STATE, db_column='3d_pipeline_val')
@@ -88,11 +96,11 @@ class SurveyTiles_3DPipelineBand1(models.Model):
     _3d_val_link = models.CharField(blank=True, null=True, db_column='3d_val_link')
     _3d_val_comments = models.TextField(blank=True, null=True, db_column='3d_val_comments')
     class Meta:
-        verbose_name = "Survey Tiles 3D Pipeline - Band 1"
+        verbose_name = "Tile States - Band 1"
         managed = False
         db_table = 'tile_3d_pipeline_band1'
 
-class SurveyTiles_3DPipelineBand2(models.Model):
+class TileStatesBand2(models.Model):
     tile_id = models.OneToOneField('survey.Tile', models.DO_NOTHING, db_column='tile_id', to_field='tile', primary_key=True)
     _3d_pipeline = models.CharField(blank=True, null=True, db_column='3d_pipeline')
     _3d_pipeline_val = models.CharField( blank=True, null=True, choices=VALIDATED_STATE, db_column='3d_pipeline_val')
@@ -101,6 +109,6 @@ class SurveyTiles_3DPipelineBand2(models.Model):
     _3d_val_link = models.CharField(blank=True, null=True, db_column='3d_val_link')
     _3d_val_comments = models.TextField(blank=True, null=True, db_column='3d_val_comments')
     class Meta:
-        verbose_name = "Survey Tiles 3D Pipeline - Band 2"
+        verbose_name = "Tile States - Band 2"
         managed = False
         db_table = 'tile_3d_pipeline_band2'

--- a/possum/survey/admin.py
+++ b/possum/survey/admin.py
@@ -5,20 +5,6 @@ from django.db.models import Q, Count, Case, When, BooleanField
 
 from .models import Observation, AssociatedTile, Tile, Validation
 
-
-def pipeline_state_colour(state):
-    colour = 'DodgerBlue'
-    if state == 'PENDING':
-        colour = 'orange'
-    elif state == 'RUNNING':
-        colour = 'SlateBlue'
-    elif state == 'COMPLETED':
-        colour = 'limegreen'
-    elif state == 'FAILED':
-        colour = 'Tomato'
-    return colour
-
-
 class AssociatedTileAdminInline(admin.TabularInline):
     model = AssociatedTile
 
@@ -35,7 +21,7 @@ class AssociatedTileAdminInline(admin.TabularInline):
 
 class Band1FieldTileAdminInline(admin.TabularInline):
     readonly_fields = ('obs_start', 'sbid', 'processed_date', 'validated_date',
-                       'validated_state', 'mfs_update', 'mfs_state', 'cube_update', 'cube_state')
+                       'validated_state')
 
     model = AssociatedTile
 
@@ -73,31 +59,6 @@ class Band1FieldTileAdminInline(admin.TabularInline):
         val = obj.name.validated_state
         if val is None:
             return '-'
-        return val
-
-    def mfs_update(self, obj):
-        val = obj.name.mfs_update
-        if val is None:
-            return '-'
-        return val
-
-    def mfs_state(self, obj):
-        val = obj.name.mfs_state
-        if val is None:
-            return '-'
-        return val
-
-    def cube_update(self, obj):
-        val = obj.name.cube_update
-        if val is None:
-            return '-'
-        return val
-
-    def cube_state(self, obj):
-        val = obj.name.cube_state
-        if val is None:
-            return '-'
-        return val
 
     def has_add_permission(self, request, obj):
         return False
@@ -112,7 +73,7 @@ class Band1FieldTileAdminInline(admin.TabularInline):
 
 class Band2FieldTileAdminInline(admin.TabularInline):
     readonly_fields = ('obs_start', 'sbid', 'processed_date', 'validated_date',
-                       'validated_state', 'mfs_update', 'mfs_state', 'cube_update', 'cube_state')
+                       'validated_state')
 
     model = AssociatedTile
 
@@ -214,18 +175,18 @@ class ValidationAdmin(admin.ModelAdmin):
 
 class ObservationAdmin(admin.ModelAdmin):
     inlines = [AssociatedTileAdminInline, ValidationAdminInline]
-    ordering = ('mfs_state', 'cube_state', 'name')
+    ordering = ('name')
 
     list_display = ('name', 'ra_deg', 'dec_deg', 'band', 'obs_start', 'sbid', 'processed_date', 'validated_date',
-                    'validated_state', 'colour_mfs_state', 'mfs_update', 'colour_cube_state', 'cube_update',)
+                    'validated_state')
 
     readonly_fields = ('name', 'ra_deg', 'dec_deg', 'gl', 'gb', 'rotation',
                        'duration', 'centrefreq', 'bandwidth', 'footprint', 'band','obs_start', 'sbid', 'processed_date', 'validated_date',
-                       'validated_state', 'mfs_update', 'mfs_state', 'cube_update', 'cube_state')
+                       'validated_state')
 
     fields = ('name', 'ra_deg', 'dec_deg', 'gl', 'gb', 'rotation', 'duration', 'centrefreq',
               'bandwidth', 'footprint', 'band', 'obs_start', 'sbid', 'processed_date', 'validated_date',
-              'validated_state', 'mfs_state', 'mfs_update', 'cube_state', 'cube_update',)
+              'validated_state')
 
     search_fields = ('name',
                      'ra_deg',
@@ -233,37 +194,11 @@ class ObservationAdmin(admin.ModelAdmin):
                      'band',
                      'sbid',
                      'validated_state',
-                     'mfs_state',
-                     'cube_state',
                      'associatedtile__tile__tile')
 
     can_delete = False
     can_add = False
     show_change_link = True
-
-    def colour_mfs_state(self, obj):
-        state = obj.mfs_state
-        if state is None:
-            return '-'
-        colour = pipeline_state_colour(state)
-        return format_html('<span style="color: {};">{}</span>',
-                           colour,
-                           obj.mfs_state)
-
-    colour_mfs_state.admin_order_field = 'mfs_state'
-    colour_mfs_state.short_description = 'mfs state'
-
-    def colour_cube_state(self, obj):
-        state = obj.cube_state
-        if state is None:
-            return '-'
-        colour = pipeline_state_colour(state)
-        return format_html('<span style="color: {};">{}</span>',
-                           colour,
-                           obj.cube_state)
-
-    colour_cube_state.admin_order_field = 'cube_state'
-    colour_cube_state.short_description = 'cube state'
 
     def has_delete_permission(self, request, obj=None):
         return False
@@ -271,14 +206,9 @@ class ObservationAdmin(admin.ModelAdmin):
 
 class TileAdmin(admin.ModelAdmin):
     inlines = [Band1FieldTileAdminInline, Band2FieldTileAdminInline,]
-    list_display = ('tile', 'ra_deg', 'dec_deg', 'gl', 'gb',
-                    'band1_count', 'band1_mfs_complete', 'band1_cube_complete',
-                    'band2_count', 'band2_mfs_complete', 'band2_cube_complete',
-                    'colour_band1_mfs_state', 'colour_band1_cube_state',
-                    'colour_band2_mfs_state', 'colour_band2_cube_state'
-                   )
-    readonly_fields = ('tile', 'ra_deg', 'dec_deg', 'gl', 'gb', 'band1_mfs_state', 'band1_cube_state', 'band2_mfs_state', 'band2_cube_state',)
-    fields = ('tile', 'ra_deg', 'dec_deg', 'gl', 'gb', 'band1_mfs_state', 'band1_cube_state', 'band2_mfs_state', 'band2_cube_state',)
+    list_display = ('tile', 'ra_deg', 'dec_deg', 'gl', 'gb', 'band1_count', 'band2_count')
+    readonly_fields = ('tile', 'ra_deg', 'dec_deg', 'gl', 'gb')
+    fields = ('tile', 'ra_deg', 'dec_deg', 'gl', 'gb')
 
     search_fields = ('tile',
                      'ra_deg',
@@ -292,102 +222,17 @@ class TileAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
-    def colour_band1_cube_state(self, obj):
-        state = obj.band1_cube_state
-        if state is None:
-            return '-'
-        colour = pipeline_state_colour(state)
-        return format_html('<span style="color: {};">{}</span>',
-                           colour,
-                           obj.band1_cube_state)
-
-    colour_band1_cube_state.admin_order_field = 'band1_cube_state'
-    colour_band1_cube_state.short_description = 'band 1 cube tile state'
-
-    def colour_band1_mfs_state(self, obj):
-        state = obj.band1_mfs_state
-        if state is None:
-            return '-'
-        colour = pipeline_state_colour(state)
-        return format_html('<span style="color: {};">{}</span>',
-                           colour,
-                           obj.band1_mfs_state)
-
-    colour_band1_mfs_state.admin_order_field = 'band1_mfs_state'
-    colour_band1_mfs_state.short_description = 'band 1 mfs tile state'
-
-    def colour_band2_cube_state(self, obj):
-        state = obj.band2_cube_state
-        if state is None:
-            return '-'
-        colour = pipeline_state_colour(state)
-        return format_html('<span style="color: {};">{}</span>',
-                           colour,
-                           obj.band2_cube_state)
-
-    colour_band2_cube_state.admin_order_field = 'band2_cube_state'
-    colour_band2_cube_state.short_description = 'band 2 cube tile state'
-
-
-    def colour_band2_mfs_state(self, obj):
-        state = obj.band2_mfs_state
-        if state is None:
-            return '-'
-        colour = pipeline_state_colour(state)
-        return format_html('<span style="color: {};">{}</span>',
-                           colour,
-                           obj.band2_mfs_state)
-
-    colour_band2_mfs_state.admin_order_field = 'band2_mfs_state'
-    colour_band2_mfs_state.short_description = 'band 2 mfs tile state'
-
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.annotate(
             band1_count=Count('fieldtile',
                               filter=Q(fieldtile__name__band=1))).order_by('band1_count')
-        qs = qs.annotate(
-            band1_mfs_complete=Case(
-                When(band1_count=Count('fieldtile',
-                                        filter=Q(fieldtile__name__band=1,
-                                        fieldtile__name__mfs_state='COMPLETED')), then=True),
-                default=False,
-                output_field=BooleanField()
-            )).order_by('-band1_mfs_complete')
-
-        qs = qs.annotate(
-            band1_cube_complete=Case(
-                When(band1_count=Count('fieldtile',
-                                        filter=Q(fieldtile__name__band=1,
-                                        fieldtile__name__cube_state='COMPLETED')), then=True),
-                default=False,
-                output_field=BooleanField()
-            )).order_by('-band1_cube_complete')
-
 
         qs = qs.annotate(
             band2_count=Count('fieldtile',
                               filter=Q(fieldtile__name__band=2))).order_by('band2_count')
-        qs = qs.annotate(
-            band2_mfs_complete=Case(
-                When(band2_count=Count('fieldtile',
-                                        filter=Q(fieldtile__name__band=2,
-                                        fieldtile__name__mfs_state='COMPLETED')), then=True),
-                default=False,
-                output_field=BooleanField()
-            )).order_by('-band2_mfs_complete')
-
-        qs = qs.annotate(
-            band2_cube_complete=Case(
-                When(band2_count=Count('fieldtile',
-                                        filter=Q(fieldtile__name__band=2,
-                                        fieldtile__name__cube_state='COMPLETED')), then=True),
-                default=False,
-                output_field=BooleanField()
-            )).order_by('-band2_cube_complete')
 
         return qs
-
 
     def band1_count(self, obj):
         return obj.band1_count
@@ -395,48 +240,11 @@ class TileAdmin(admin.ModelAdmin):
     band1_count.admin_order_field = 'band1_count'
     band1_count.short_description = 'Band 1'
 
-    def band1_mfs_complete(self, obj):
-        if obj.band1_count == 0:
-            return False
-        return obj.band1_mfs_complete
-
-    band1_mfs_complete.admin_order_field = 'band1_mfs_complete'
-    band1_mfs_complete.short_description = 'Band 1 mfs complete'
-    band1_mfs_complete.boolean = True
-
-    def band1_cube_complete(self, obj):
-        if obj.band1_count == 0:
-            return False
-        return obj.band1_cube_complete
-
-    band1_cube_complete.admin_order_field = 'band1_cube_complete'
-    band1_cube_complete.short_description = 'Band 1 cube complete'
-    band1_cube_complete.boolean = True
-
     def band2_count(self, obj):
         return obj.band2_count
 
     band2_count.admin_order_field = 'band2_count'
     band2_count.short_description = 'Band 2'
-
-    def band2_mfs_complete(self, obj):
-        if obj.band2_count == 0:
-            return False
-        return obj.band2_mfs_complete
-
-    band2_mfs_complete.admin_order_field = 'band2_mfs_complete'
-    band2_mfs_complete.short_description = 'Band 2 mfs complete'
-    band2_mfs_complete.boolean = True
-
-    def band2_cube_complete(self, obj):
-        if obj.band2_count == 0:
-            return False
-        return obj.band2_cube_complete
-
-    band2_cube_complete.admin_order_field = 'band2_cube_complete'
-    band2_cube_complete.short_description = 'Band 2 cube complete'
-    band2_cube_complete.boolean = True
-
 
 admin.site.register(Observation, ObservationAdmin)
 admin.site.register(Tile, TileAdmin)

--- a/possum/survey/admin.py
+++ b/possum/survey/admin.py
@@ -3,7 +3,7 @@ from django.utils.html import format_html
 from django.db.models.aggregates import Count
 from django.db.models import Q, Count, Case, When, BooleanField
 
-from .models import Observation, AssociatedTile, FieldTile, Tile, Validation
+from .models import Observation, AssociatedTile, Tile, Validation
 
 
 def pipeline_state_colour(state):
@@ -37,7 +37,7 @@ class Band1FieldTileAdminInline(admin.TabularInline):
     readonly_fields = ('obs_start', 'sbid', 'processed_date', 'validated_date',
                        'validated_state', 'mfs_update', 'mfs_state', 'cube_update', 'cube_state')
 
-    model = FieldTile
+    model = AssociatedTile
 
     can_delete = False
     can_add = False
@@ -114,7 +114,7 @@ class Band2FieldTileAdminInline(admin.TabularInline):
     readonly_fields = ('obs_start', 'sbid', 'processed_date', 'validated_date',
                        'validated_state', 'mfs_update', 'mfs_state', 'cube_update', 'cube_state')
 
-    model = FieldTile
+    model = AssociatedTile
 
     can_delete = False
     can_add = False

--- a/possum/survey/models.py
+++ b/possum/survey/models.py
@@ -23,19 +23,7 @@ class AssociatedTile(models.Model):
         managed = False
         db_table = 'associated_tile'
         unique_together = (('name', 'tile'),)
-
-
-class FieldTile(models.Model):
-    id = models.BigAutoField(primary_key=True)
-    tile = models.ForeignKey('Tile', models.DO_NOTHING, db_column='tile', to_field='tile', blank=True, null=True)
-    name = models.ForeignKey('Observation', models.DO_NOTHING, db_column='name', to_field='name', blank=True, null=True)
-
-    class Meta:
-        managed = False
-        db_table = 'field_tile'
-        unique_together = (('name', 'tile'),)
-
-
+        
 class Observation(models.Model):
     name = models.TextField(primary_key=True)
     ra_deg = models.DecimalField(max_digits=65535, decimal_places=4, blank=True, null=True)
@@ -59,7 +47,7 @@ class Observation(models.Model):
     cube_state = models.TextField(blank=True, null=True)
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
     class Meta:
         managed = False

--- a/possum/survey/models.py
+++ b/possum/survey/models.py
@@ -41,10 +41,6 @@ class Observation(models.Model):
     processed_date = models.DateTimeField(blank=True, null=True)
     validated_date = models.DateTimeField(blank=True, null=True)
     validated_state = models.TextField(blank=True, null=True)
-    mfs_update = models.DateTimeField(blank=True, null=True)
-    mfs_state = models.TextField(blank=True, null=True)
-    cube_update = models.DateTimeField(blank=True, null=True)
-    cube_state = models.TextField(blank=True, null=True)
 
     def __str__(self):
         return str(self.name)
@@ -60,16 +56,6 @@ class Tile(models.Model):
     dec_deg = models.DecimalField(max_digits=65535, decimal_places=4, blank=True, null=True)
     gl = models.DecimalField(max_digits=65535, decimal_places=4, blank=True, null=True)
     gb = models.DecimalField(max_digits=65535, decimal_places=4, blank=True, null=True)
-    oned_pipeline_main_band1 = models.DateTimeField(db_column='1d_pipeline_main_band1', blank=True, null=True)  # Field renamed because it wasn't a valid Python identifier.
-    oned_pipeline_borders_band1 = models.DateTimeField(db_column='1d_pipeline_borders_band1', blank=True, null=True)  # Field renamed because it wasn't a valid Python identifier.
-    threed_pipeline_band1 = models.DateTimeField(db_column='3d_pipeline_band1', blank=True, null=True)  # Field renamed because it wasn't a valid Python identifier.
-    oned_pipeline_main_band2 = models.DateTimeField(db_column='1d_pipeline_main_band2', blank=True, null=True)  # Field renamed because it wasn't a valid Python identifier.
-    oned_pipeline_borders_band2 = models.DateTimeField(db_column='1d_pipeline_borders_band2', blank=True, null=True)  # Field renamed because it wasn't a valid Python identifier.
-    threed_pipeline_band2 = models.DateTimeField(db_column='3d_pipeline_band2', blank=True, null=True)  # Field renamed because it wasn't a valid Python identifier.
-    band1_cube_state = models.TextField(blank=True, null=True)
-    band1_mfs_state = models.TextField(blank=True, null=True)
-    band2_mfs_state = models.TextField(blank=True, null=True)
-    band2_cube_state = models.TextField(blank=True, null=True)
 
     def __str__(self):
         return str(self.tile)


### PR DESCRIPTION
* Deleted field_tile (I kept associated_tile because it's used in Cameron's polarimetry github).
* Separated state columns from "tile" table into TileStatesBand1 and TileStatesBand2 tables.
* Similarly for "observation" table, into ObservationStatesBand1 and ObservationStatesBand2 tables.

This is mainly to see if we're on the same page with the table structure, before spending too much efforts refactoring.. I am not sure what Dave was doing with the ordering by and counting by bands, I think he was trying to order the tables by band and completion states.. I'll revisit when you approve.

After this, we'll need to update the scripts in the POSSUM utils to reflect the new tables.
